### PR TITLE
Bump zstd to v0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ flate2 = { version = "1.0", optional = true }
 lz4_flex = { version = "0.9.2", optional = true }
 snap = { version = "1.0.5", optional = true }
 tempfile = { version = "3.2.0", optional = true }
-zstd = { version = "0.9.0", optional = true }
+zstd = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }


### PR DESCRIPTION
This PR bumps the zstd version to 0.10.0 and must wait for #26 in order to be merged.