### PR TITLE
Optionally use an unstable sort algorithm for the Sorter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,9 @@ pub use self::metadata::FileVersion;
 pub use self::reader::{PrefixIter, RangeIter, Reader, ReaderCursor, RevPrefixIter, RevRangeIter};
 #[cfg(feature = "tempfile")]
 pub use self::sorter::TempFileChunk;
-pub use self::sorter::{ChunkCreator, CursorVec, DefaultChunkCreator, Sorter, SorterBuilder};
+pub use self::sorter::{
+    ChunkCreator, CursorVec, DefaultChunkCreator, SortAlgorithm, Sorter, SorterBuilder,
+};
 pub use self::writer::{Writer, WriterBuilder};
 
 /// Sometimes we need to use an unsafe trick to make the compiler happy.


### PR DESCRIPTION
# Pull Request

## What does this PR do?
The `SorterBuilder` now accepts a `SortAlgorithm` argument, which can be either `Stable` and `Unstable`. This value determines whether the entries in the internal vector are sorted using `.sort_by_key` or `.sort_unstable_by_key`. Stable sort is the default and keeps the relative order of values with equal keys. Unstable sort is free to rearrange the values in any order, but it is faster, sometimes significantly so.
