### PR TITLE
Bump the dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,19 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
-bytemuck = { version = "1.7.0", features = ["derive"] }
-byteorder = "1.3.4"
+bytemuck = { version = "1.13.0", features = ["derive"] }
+byteorder = "1.4.3"
 flate2 = { version = "1.0", optional = true }
-lz4_flex = { version = "0.9.2", optional = true }
-snap = { version = "1.0.5", optional = true }
-tempfile = { version = "3.2.0", optional = true }
-zstd = { version = "0.10.0", optional = true }
+lz4_flex = { version = "0.10.0", optional = true }
+snap = { version = "1.1.0", optional = true }
+tempfile = { version = "3.3.0", optional = true }
+zstd = { version = "0.12.3", optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.3", features = ["html_reports"] }
-quickcheck = "0.9"
-rand = "0.8.4"
-grenad-0-4 = { version = "0.4.1", package = "grenad" }
+criterion = { version = "0.4", features = ["html_reports"] }
+quickcheck = "1.0"
+rand = "0.8.5"
+grenad-0-4 = { version = "0.4.1", package = "grenad" } # do not update, backward compatibility test
 
 [[bench]]
 name = "index-levels"


### PR DESCRIPTION
This pull request bumps the dependency versions, even for incompatible ones. Please check carefully the bump of the incompatible ones, i.e, `lz4_flex`, `zstd`, `quickcheck`.