### PR TITLE
Glidesort experiments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT"
 bytemuck = { version = "1.7.0", features = ["derive"] }
 byteorder = "1.3.4"
 flate2 = { version = "1.0", optional = true }
-# Uses glidesort in the sorter instead of the slower std methods
 glidesort = { version = "0.1.2", optional = true }
 lz4_flex = { version = "0.9.2", optional = true }
 snap = { version = "1.0.5", optional = true }
@@ -31,6 +30,10 @@ harness = false
 
 [features]
 default = ["tempfile", "snappy"]
+# Uses glidesort in the sorter to **stable sort** instead of the slower std methods
+glidesort-stable = ["glidesort"]
+# Uses glidesort in the sorter to **unstable sort** instead of the slower std methods
+glidesort-unstable = ["glidesort"]
 snappy = ["snap"]
 zlib = ["flate2"]
 lz4 = ["lz4_flex"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ license = "MIT"
 bytemuck = { version = "1.7.0", features = ["derive"] }
 byteorder = "1.3.4"
 flate2 = { version = "1.0", optional = true }
+# Uses glidesort in the sorter instead of the slower std methods
+glidesort = { version = "0.1.2", optional = true }
 lz4_flex = { version = "0.9.2", optional = true }
 snap = { version = "1.0.5", optional = true }
 tempfile = { version = "3.2.0", optional = true }

--- a/src/sorter.rs
+++ b/src/sorter.rs
@@ -273,7 +273,13 @@ impl Entries {
         let (bounds, tail) = self.buffer.split_at_mut(bounds_end);
         let bounds = cast_slice_mut::<_, EntryBound>(bounds);
         let sort = match algorithm {
+            #[cfg(feature = "glidesort-stable")]
+            SortAlgorithm::Stable => glidesort::sort_by_key::<EntryBound, _, _>,
+            #[cfg(not(feature = "glidesort-stable"))]
             SortAlgorithm::Stable => <[EntryBound]>::sort_by_key,
+            #[cfg(feature = "glidesort-unstable")]
+            SortAlgorithm::Unstable => glidesort::sort_by_key::<EntryBound, _, _>,
+            #[cfg(not(feature = "glidesort-unstable"))]
             SortAlgorithm::Unstable => <[EntryBound]>::sort_unstable_by_key,
         };
         sort(bounds, |b: &EntryBound| &tail[tail.len() - b.key_start..][..b.key_length as usize]);


### PR DESCRIPTION
This PR exposes two cargo features to enable glidesort as the sort algorithm for the grenad Sorter:
 - `glidesort-stable`: Use glidesort to stable sort in the Sorter instead of using the std sort algorithms.
 - `glidesort-unstable`: Use glidesort to unstable sort in the Sorter. Note that it will use a stable sort as glidesort doesn't support unstable sorting but is usually faster than the unstable sorting of the std.

Glidesort can also [take the external buffer as a parameter](https://docs.rs/glidesort/latest/glidesort/fn.sort_with_buffer_by_key.html) which allows us to reduce the number of new allocations and speedup the Sorter again. The Sorter could allocate this buffer when created and keep it until dropped. Still, it could just take a slice of the available memory in the big buffer already allocated to store the keys and `EntryBounds`. It is a possible future work in this PR.

