### PR TITLE
Expose a new `SorterBuilder::sort_in_parallel` method

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,10 @@ jobs:
           command: test
           args: --all-features
 
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ bytemuck = { version = "1.7.0", features = ["derive"] }
 byteorder = "1.3.4"
 flate2 = { version = "1.0", optional = true }
 lz4_flex = { version = "0.9.2", optional = true }
+rayon = { version = "1.7.0", optional = true }
 snap = { version = "1.0.5", optional = true }
 tempfile = { version = "3.2.0", optional = true }
 zstd = { version = "0.10.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,21 @@
 //! The entries in the grenad files are _immutable_ and the only way to modify them is by _creating
 //! a new file_ with the changes.
 //!
-//! # Example: Use the `Writer` and `Reader` structs
+//! # Features
+//!
+//! You can define which compression schemes to support, there are currently a few
+//! available choices, these determine which types will be available inside the above modules:
+//!
+//! - _Snappy_ with the [`snap`](https://crates.io/crates/snap) crate.
+//! - _Zlib_ with the [`flate2`](https://crates.io/crates/flate2) crate.
+//! - _Lz4_ with the [`lz4_flex`](https://crates.io/crates/lz4_flex) crate.
+//!
+//! If you need more performances you can enable the `rayon` feature that will enable a bunch
+//! of new settings like being able to make the `Sorter` sort in parallel.
+//!
+//! # Examples
+//!
+//! ## Use the `Writer` and `Reader` structs
 //!
 //! You can use the [`Writer`] struct to store key-value pairs into the specified
 //! [`std::io::Write`] type. The [`Reader`] type can then be used to read the entries.
@@ -37,7 +51,7 @@
 //! # Ok(()) }
 //! ```
 //!
-//! # Example: Use the `Merger` struct
+//! ## Use the `Merger` struct
 //!
 //! In this example we show how you can merge multiple [`Reader`]s
 //! by using a _merge function_ when a conflict is encountered.
@@ -107,7 +121,7 @@
 //! # Ok(()) }
 //! ```
 //!
-//! # Example: Use the `Sorter` struct
+//! ## Use the `Sorter` struct
 //!
 //! In this example we show how by defining a _merge function_, we can insert
 //! multiple entries with the same key and output them in lexicographic order.


### PR DESCRIPTION
This pull request exposes a new method to use rayon to sort the entries in parallel. This is not breaking as it only introduces a new `rayon` feature and `SorterBuilder` method.