### PR TITLE
error: fix 'occured' -> 'occurred' in doc comments

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,9 +4,9 @@ use std::{error, fmt, io};
 /// Represents an error that can occur while using this library.
 #[derive(Debug)]
 pub enum Error<U = Infallible> {
-    /// An [`io::Error`] occured either while reading or writing.
+    /// An [`io::Error`] occurred either while reading or writing.
     Io(io::Error),
-    /// A merge error occured while trying to merge values.
+    /// A merge error occurred while trying to merge values.
     Merge(U),
     /// An invalid [`crate::CompressionType`] has been encountered.
     InvalidCompressionType,


### PR DESCRIPTION
Doc comments in `src/error.rs` (lines 7, 9) read `occured`. Fixed to `occurred`. Comment-only change.